### PR TITLE
Misc API Cleanup

### DIFF
--- a/call_status.nimble
+++ b/call_status.nimble
@@ -24,8 +24,8 @@ task db_setup, "Set up the DB":
   exec "./misc/db_setup.sh"
 
 task docs, "Generate documentation":
-  exec "nim doc --project src/check_zoom.nim"
-  exec "nim doc --project src/cli.nim"
+  exec "nimble doc --project src/check_zoom.nim"
+  exec "nimble doc --project src/cli.nim"
   # Web currently errors here, will have to figure out why
   # exec "nim doc --project src/web.nim"
 

--- a/misc/db_setup.sh
+++ b/misc/db_setup.sh
@@ -15,7 +15,7 @@ sql_content() {
 CREATE TABLE people (
   id         SERIAL PRIMARY KEY,
   name       TEXT NOT NULL,
-  is_on_call BOOLEAN
+  is_on_call BOOLEAN NOT NULL
 );
 
 -- Populate table

--- a/src/api_client.nim
+++ b/src/api_client.nim
@@ -28,15 +28,16 @@ proc sendJson(api: ApiClient, httpMethod: HttpMethod, relativeUrl: string, bodyJ
     httpMethod = httpMethod,
     body = body
   )
-  if is5xx result.code: raise newException(HttpRequestError, $result.status)
+  if is4xx(result.code) or is5xx(result.code):
+    raise newException(HttpRequestError, $result.status)
   debug result.status
   if result.body != "": debug result.body
 
 
 proc getPeople*(api: ApiClient): seq[Person] =
   # The relative path is a little weird, but it's fine for now
-  let response = api.sendJson(HttpGet, "/api/status")
+  let response = api.sendJson(HttpGet, "/api/people")
   person.fromJsonMany parseJson(response.body)
 
 proc updatePerson*(api: ApiClient, person: Person) =
-  discard api.sendJson(HttpPost, "/api/status", %*person)
+  discard api.sendJson(HttpPut, "/api/person/" & person.name, %*person)

--- a/src/check_zoom.nim
+++ b/src/check_zoom.nim
@@ -63,13 +63,13 @@ proc main(name: string, apiBaseUrl: string, dryRun: bool, force: bool) =
   let current = isZoomCallActive()
 
   if (not force) and lastKnown.isSome and lastKnown.get() == current:
-    info "Status unchanged. Doing nothing."
+    info "Status unchanged; doing nothing."
     quit 0
   else:
     if dryRun:
-      info "New status, but dry run. Doing nothing."
+      info "New status (or just forced update), but dry run; doing nothing."
       return
-    info "Updating."
+    info "New status (or just forced update); updating."
     let person = Person(
       name: name,
       status: status.fromIsOnCall current

--- a/src/check_zoom.nim
+++ b/src/check_zoom.nim
@@ -5,16 +5,20 @@ import logging
 import options
 import os
 import strutils
+import uri
 
 import ./api_client
 import ./db
 import ./detect_zoom
-let db_open = open_sqlite
 import ./misc
+import ./models/person
+import ./models/status
 
 block logging:
   let logger = newConsoleLogger(fmtStr = "[$datetime][$levelname] ")
   addHandler logger
+
+let db_open = open_sqlite
 
 proc dbSetup() =
   db_open().use do (conn: DbConn):
@@ -33,15 +37,15 @@ proc tryParseBool(str: string): Option[bool] =
   else:
     try: some parseBool(str) except ValueError: none bool
 
-proc getLastKnownLocalStatus(conn: DbConn, user: string): Option[bool] =
+proc getLastKnownLocalStatus(conn: DbConn, name: string): Option[bool] =
   let query = sql dedent """
     SELECT is_on_call
     FROM statuses
     WHERE name = ?"""
   debug query.string
-  tryParseBool conn.getValue(query, user)
+  tryParseBool conn.getValue(query, name)
 
-proc updateLocalStatus(conn: DbConn, user: string, isOnCall: bool) =
+proc updatePerson(conn: DbConn, person: Person) =
   let query = sql dedent """
     INSERT INTO statuses (name, is_on_call, last_checked) VALUES
       (?, ?, current_timestamp)
@@ -49,12 +53,13 @@ proc updateLocalStatus(conn: DbConn, user: string, isOnCall: bool) =
         is_on_call = ?,
         last_checked = current_timestamp"""
   debug query.string
-  conn.exec query, user, isOnCall, isOnCall
+  let isOnCall = person.isOnCall()
+  conn.exec query, person.name, isOnCall, isOnCall
 
-proc main(user: string, apiBaseUrl: string, dryRun: bool) =
+proc main(name: string, apiBaseUrl: string, dryRun: bool) =
   dbsetup()
   let lastKnown = db_open().use do (conn: DbConn) -> Option[bool]:
-    getLastKnownLocalStatus(conn, user)
+    getLastKnownLocalStatus(conn, name)
   let current = isZoomCallActive()
 
   if lastKnown.isSome and lastKnown.get() == current:
@@ -64,12 +69,13 @@ proc main(user: string, apiBaseUrl: string, dryRun: bool) =
     if dryRun:
       info "New Status, but dry run. Doing nothing."
       return
-
     info "New status. Updating."
-
-    discard postStatus(apiBaseUrl, user, current)
-
-    db_open().use do (conn: DbConn): updateLocalStatus conn, user, current
+    let person = Person(
+      name: name,
+      status: status.fromIsOnCall current
+    )
+    newApiClient(apiBaseUrl).updatePerson person
+    db_open().use do (conn: DbConn): conn.updatePerson person
 
 let p = newParser("check-zoom"):
   help "Check Zoom call status and update Call Status API accordingly"

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -2,7 +2,10 @@ import argparse
 import httpClient
 import logging
 import os
+
 import ./api_client
+import ./models/person
+import ./models/status
 
 block logging:
   addHandler newConsoleLogger(fmtStr = "[$levelname] ")
@@ -30,6 +33,10 @@ let p = newParser("call-status"):
     if opts.dryRun:
       echo "Would set ", opts.user, "\'s status to ", opts.status, "."
     else:
-      discard postStatus(opts.apiBaseUrl, opts.user, parseBool opts.status)
+      let person = Person(
+        name: opts.user,
+        status: status.fromIsOnCall parseBool(opts.status)
+      )
+      newApiClient(opts.apiBaseUrl).updatePerson person
 
 p.run()

--- a/src/deprecations.nim
+++ b/src/deprecations.nim
@@ -5,4 +5,5 @@ proc isSupported(key: string, default: bool = true): bool =
   let fullKey = "DEPRECATION_SUPPORT_" & key
   parseBool getEnv(fullKey, default = $default)
 
-let userKeySupported* = isSupported("USER_KEY", default = true)
+let userKeySupported* = isSupported "USER_KEY"
+let apiStatusEndpoints* = isSupported "API_STATUS_ENDPOINTS"

--- a/src/deprecations.nim
+++ b/src/deprecations.nim
@@ -1,0 +1,8 @@
+import os
+import strUtils
+
+proc isSupported(key: string, default: bool = true): bool =
+  let fullKey = "DEPRECATION_SUPPORT_" & key
+  parseBool getEnv(fullKey, default = $default)
+
+let userKeySupported* = isSupported("USER_KEY", default = true)

--- a/src/models/person.nim
+++ b/src/models/person.nim
@@ -1,4 +1,5 @@
 import json
+import seqUtils
 import ./status
 
 # This is a duplicate of db_*'s `Row`.
@@ -19,9 +20,12 @@ proc fromJson*(jsonNode: JsonNode): Person =
   let status = status.fromIsOnCall(jsonNode["is_on_call"].getBool())
 
   Person(
-    name: jsonNode["user"].getStr(),
+    name: jsonNode["name"].getStr(),
     status: status,
   )
+
+proc fromJsonMany*(jsonNode: JsonNode): seq[Person] =
+  jsonNode.getElems().map fromJson
 
 proc isOnCall*(person: Person): bool =
   status.isOnCall person.status

--- a/src/models/person.nim
+++ b/src/models/person.nim
@@ -1,5 +1,7 @@
 import json
 import seqUtils
+
+import ../deprecations
 import ./status
 
 # This is a duplicate of db_*'s `Row`.
@@ -18,11 +20,17 @@ proc fromPgRow*(row: Row): Person =
 
 proc fromJson*(jsonNode: JsonNode): Person =
   let status = status.fromIsOnCall(jsonNode["is_on_call"].getBool())
-
-  Person(
-    name: jsonNode["name"].getStr(),
-    status: status,
+  let name = getStr(
+    if deprecations.userKeySupported:
+      try:
+        jsonNode["name"]
+      except KeyError:
+        jsonNode["user"]
+    else:
+      jsonNode["name"]
   )
+
+  Person(name: name, status: status)
 
 proc fromJsonMany*(jsonNode: JsonNode): seq[Person] =
   jsonNode.getElems().map fromJson
@@ -32,6 +40,6 @@ proc isOnCall*(person: Person): bool =
 
 proc `%`*(person: Person): JsonNode =
   %[
-    ("name", %person.name),
+    ("user", %person.name),
     ("is_on_call", %person.isOnCall()),
   ]

--- a/src/views/index.nim
+++ b/src/views/index.nim
@@ -29,7 +29,7 @@ proc renderPerson*(person: Person): string =
   let statusClass = presenter.statusClass
 
   let form = h.form(
-    action = "set_status/" & person.name,
+    action = "/person/" & person.name,
     `method` = "POST",
     h.input(
       `type` = "hidden",


### PR DESCRIPTION
Mostly, choosing to use `name` instead of `user`.

The Zoom watcher daemons happen to post with `user`, though so that'll have to remain deprecated, but with support, until everyone involved gets theirs updated.