### PR TITLE
Reshuffle CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build call_status_checker -y
+    - run: nimble build dump
 
   build-web:
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build web -y
+    - run: nimble build dump
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build -y call_status_checker
+    - run: nimble build call_status_checker -y
 
   build-web:
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build -y web
+    - run: nimble build web -y
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,28 +6,16 @@ on:
 
 jobs:
   assets:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Cache choosenim
-      id: cache-choosenim
-      uses: actions/cache@v1
-      with:
-        path: ~/.choosenim
-        key: ${{ runner.os }}-choosenim-stable
-    - name: Cache nimble
-      id: cache-nimble
-      uses: actions/cache@v1
-      with:
-        path: ~/.nimble
-        key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.0.2
 
     - run: nimble install -y nimassets
     - run: nimble assets
     - run: git diff --exit-code
 
-  build:
+  build-call_status_checker:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -45,24 +33,20 @@ jobs:
         key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build -y
+    - run: nimble build -y call_status_checker
 
-  docs:
-    runs-on: macos-latest
+  build-web:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Cache choosenim
-      id: cache-choosenim
-      uses: actions/cache@v1
-      with:
-        path: ~/.choosenim
-        key: ${{ runner.os }}-choosenim-stable
-    - name: Cache nimble
-      id: cache-nimble
-      uses: actions/cache@v1
-      with:
-        path: ~/.nimble
-        key: ${{ runner.os }}-nimble-stable
+    - uses: jiro4989/setup-nim-action@v1.0.2
+
+    - run: nimble build -y web
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1.0.2
 
     - run: nimble install -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1.0.2
 
+    - run: nimble install -y
     - run: nimble build dump
 
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
         key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build -y # call_status_checker # (for some reason even w/ a valid binary)
+    # (for some reason even w/ a valid binary)
+    - run: echo nimble build -y call_status_checker
+    - run: nimble build -y
 
 
   build-web:
@@ -42,8 +44,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build -y # web # (for some reason even w/ a valid binary)
-
+    # (for some reason even w/ a valid binary)
+    - run: echo nimble build -y web
+    - run: nimble build -y #
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: jiro4989/setup-nim-action@v1.0.2
 
     - run: nimble install -y
-    - run: nimble build dump
+    - run: nimble build dump --verbose
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
         key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble build dump
+    - run: nimble build -y # call_status_checker # (for some reason even w/ a valid binary)
+
 
   build-web:
     runs-on: ubuntu-latest
@@ -41,8 +42,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1.0.2
 
-    - run: nimble install -y
-    - run: nimble build dump --verbose
+    - run: nimble build -y # web # (for some reason even w/ a valid binary)
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Jobs `assets`, `docs` both run on `ubuntu-latest`

* Split `build` up:
  * `build-web` runs on `ubuntu-latest`
  * `build-call_status_checker` runs on `macos-latest`