### PR TITLE
Try reading revision from envvar first

### DIFF
--- a/src/statics.nim
+++ b/src/statics.nim
@@ -1,6 +1,7 @@
 import parsecfg
 import streams
 import strutils
+import os
 
 proc getPkgVersion(): string {.compileTime.} =
   const filepath = staticExec("ls ../*.nimble").splitLines()[0]
@@ -13,7 +14,10 @@ proc getPkgVersion(): string {.compileTime.} =
     close stream
 
 proc getPkgRevision(): string {.compileTime.} =
-  staticExec "git rev-parse HEAD"
+  let fromEnv = getEnv "SOURCE_VERSION"
+  if fromEnv != "": fromEnv
+  else:
+    staticExec "git rev-parse HEAD"
 
 const pkgVersion* = getPkgVersion()
 

--- a/src/web.nim
+++ b/src/web.nim
@@ -23,8 +23,8 @@ if existsEnv("PORT"):
 
 logs.setupWeb()
 
-debug "version:  ", pkgVersion
-debug "revision: ", pkgRevision
+info "version:  ", pkgVersion
+info "revision: ", pkgRevision
 
 proc updateStatus(person: Person) =
   let query = sql dedent """


### PR DESCRIPTION
This is to address https://github.com/awseward/call_status/issues/24.

Luckily HEROKU provides `SOURCE_VERSION` that can we can just pull this
information from.

Also included in this change is a switch from `debug` to `info` for this
information.