### PR TITLE
Skip `build-call_status_checker` for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     - run: git diff --exit-code
 
   build-call_status_checker:
+    # FIXME: Solve the flaky cache issue and then turn this job back on
+    if: false
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Once the flaky cache issue is resolved, this can get reenabled, but 5 minute builds are just too long.

When the cache was working, the nim env setup step only took ~30s.

To have this job back in, it's gotta be faster than that.