### PR TITLE
Un-shoutcase consts

### DIFF
--- a/src/call_status_checker.nim
+++ b/src/call_status_checker.nim
@@ -87,13 +87,13 @@ proc runCheck(name: string, apiBaseUrl: string, dryRun: bool, force: bool) =
 proc runConfig(name: string) =
   CheckerConfig(userName: name).writeConfigFile getEnv("CONFIG_FILEPATH")
 
-const APP_NAME = "call_status_checker"
+const AppName = "call_status_checker"
 
-let p = newParser(APP_NAME):
+let p = newParser(AppName):
   help "Check call status and update Call Status API accordingly"
 
-  flag("--version", help = "Print the version of " & APP_NAME)
-  flag("--revision", help = "Print the Git SHA of " & APP_NAME)
+  flag("--version", help = "Print the version of " & AppName)
+  flag("--revision", help = "Print the Git SHA of " & AppName)
   flag("--info", help = "Print version and revision")
 
   command "config":

--- a/src/checker_config.nim
+++ b/src/checker_config.nim
@@ -2,11 +2,11 @@ import json
 import options
 import logs
 
-const USER_NAME = "user_name"
+const UserName = "user_name"
 
 type ConfigFilepath = distinct string
 
-const DEFAULT_CONFIG_FILEPATH =
+const DefaultConfigFilepath =
   when hostOS == "macosx":
     # Basis of this filepath is homebrew installation directory choices.
     #
@@ -31,7 +31,7 @@ const DEFAULT_CONFIG_FILEPATH =
 
 proc fromString(str: string): ConfigFilepath =
   if str == "":
-    DEFAULT_CONFIG_FILEPATH
+    DefaultConfigFilepath
   else:
     ConfigFilepath str
 
@@ -42,11 +42,11 @@ type CheckerConfig* = object
 
 proc fromJson(jsonStr: string): CheckerConfig =
   let json = parseJson jsonStr
-  CheckerConfig(userName: json[USER_NAME].getStr())
+  CheckerConfig(userName: json[UserName].getStr())
 
 proc `%`(config: CheckerConfig): JsonNode =
   %*{
-    USER_NAME: %config.user_name
+    UserName: %config.user_name
   }
 
 proc tryRead(filepath: ConfigFilepath): Option[CheckerConfig] =

--- a/src/deprecations.nim
+++ b/src/deprecations.nim
@@ -22,5 +22,5 @@ template check*(deprecation, supported, logProc, actions: untyped): untyped =
 
 # ---
 
-const USER_KEY* = Deprecation "USER_KEY"
-const API_STATUS_ENDPOINTS* = Deprecation "API_STATUS_ENDPOINTS"
+const UserKey* = Deprecation "USER_KEY"
+const ApiStatusEndpoints* = Deprecation "API_STATUS_ENDPOINTS"

--- a/src/detect_zoom.nim
+++ b/src/detect_zoom.nim
@@ -4,11 +4,11 @@ import system
 
 import ./misc
 
-const MACOS_COMMAND = "ps aux | grep -c --regexp='zoom.*[C]ptHost'"
+const MacosCommand = "ps aux | grep -c --regexp='zoom.*[C]ptHost'"
 
 proc isZoomCallActive*(): bool =
   when hostOS == "macosx":
-    let (output, errorCode) = execCmdEx MACOS_COMMAND
+    let (output, errorCode) = execCmdEx MacosCommand
     let exitZero = (errorCode == 0)
     let parsedOutput = parseint(output.strip())
 

--- a/src/models/person.nim
+++ b/src/models/person.nim
@@ -24,7 +24,7 @@ proc fromJson*(jsonNode: JsonNode): Person =
   let name = getStr(
     try: jsonNode["name"]
     except KeyError:
-      deprecations.USER_KEY.check supported, logProc:
+      deprecations.UserKey.check supported, logProc:
         logProc()
         if not supported: raise
         else:

--- a/src/web.nim
+++ b/src/web.nim
@@ -65,7 +65,7 @@ proc getPeople(): seq[Person] =
 router api:
   # DEPRECATED
   get "/status":
-    deprecations.API_STATUS_ENDPOINTS.check(supported, logProc):
+    deprecations.ApiStatusEndpoints.check(supported, logProc):
       logProc()
       if not supported: halt Http404
 
@@ -75,7 +75,7 @@ router api:
 
   # DEPRECATED
   post "/status":
-    deprecations.API_STATUS_ENDPOINTS.check(supported, logProc):
+    deprecations.ApiStatusEndpoints.check(supported, logProc):
       logProc()
       if not supported: halt Http404
 


### PR DESCRIPTION
From https://nim-lang.org/docs/nep1.html#introduction-naming-conventions:

> [...] ALL_UPPERCASE are allowed, but ugly. (Why shout CONSTANT?
> Constants do no harm, variables do!)