### PR TITLE
Add client "up" endpoint

### DIFF
--- a/src/db.nim
+++ b/src/db.nim
@@ -2,9 +2,6 @@ import junk_drawer/db
 import os
 import db_postgres
 import db_sqlite
-import typetraits
-
-import ./logs
 
 export db
 

--- a/src/patchbay.nim
+++ b/src/patchbay.nim
@@ -9,17 +9,25 @@ import redis
 import sequtils
 import strutils
 import sugar
+import times
 import uri
 
 import ./logs
 
 const pubsubBaseUri = parseUri "https://patchbay.pub/pubsub"
 
-type ChannelId = distinct string
+type ClientId = distinct string
+
+type PatchbayChannel* = object
+  uri*: Uri
+  expires*: Time
 
 # Redis stuff...
 
 const DaySeconds = 1 * 24 * 60 * 60
+
+proc whUrlKey(clientId: ClientId): string =
+  "webhookUrl:" & clientId.string
 
 proc getRedisClient(): Redis =
   let rUri = parseUri getEnv("REDIS_URL")
@@ -30,22 +38,26 @@ proc getRedisClient(): Redis =
   if rUri.password != "":
     result.auth rUri.password
 
-proc pbRegister*(clientId: string, path = ""): Uri =
-  let channelId = encode(clientId, safe = true)
+proc pbRegister*(rawClientId: string, path = ""): PatchbayChannel =
+  let key = whUrlKey ClientId(rawClientId)
+  let uri = pubsubBaseUri / encode(rawClientId, safe = true) / path
   let client = getRedisClient()
-  discard client.setEx("clientid:" & clientId, DaySeconds, channelId)
-  pubsubBaseUri / channelId / path
+  discard client.setEx(key, DaySeconds, $uri)
+  let expires = getTime() + client.ttl(key).int.seconds
+  result = PatchbayChannel(uri: uri, expires: expires)
+  client.quit()
 
-proc getChannelIds(): seq[ChannelId] =
+proc getAllPbUris(): seq[Uri] =
   let client = getRedisClient()
-  client.keys("clientid:*").map(k => ChannelId client.get(k))
+  let pattern = whUrlKey ClientId("*")
+  result = client.keys(pattern).map(key => parseUri client.get(key))
+  client.quit()
 
-proc pbPublish*(path: string, json: JsonNode): Future[void] {.async.} =
+proc pbPublish*(json: JsonNode): Future[void] {.async.} =
   let http = newAsyncHttpClient(
     headers = newHttpHeaders { "Content-Type": "application/json" }
   )
   let httpMethod = HttpPost
-  for channelId in getChannelIds():
-    let uri = pubsubBaseUri / channelId.string / path
-    debug httpMethod, " ", uri
-    discard (await http.request($uri, httpMethod, body = $json))
+  for pbUri in getAllPbUris():
+    debug httpMethod, " ", pbUri
+    discard await http.request($pbUri, httpMethod, body = $json)

--- a/src/patchbay.nim
+++ b/src/patchbay.nim
@@ -55,7 +55,7 @@ proc getAllPbUris(): seq[Uri] =
 
 proc pbPublish*(json: JsonNode): Future[void] {.async.} =
   let http = newAsyncHttpClient(
-    headers = newHttpHeaders { "Content-Type": "application/json" }
+    headers = newHttpHeaders {"Content-Type": "application/json"}
   )
   let httpMethod = HttpPost
   for pbUri in getAllPbUris():

--- a/src/websockets.nim
+++ b/src/websockets.nim
@@ -1,0 +1,13 @@
+import asyncdispatch
+import ws
+
+var websockets: seq[WebSocket] = @[]
+
+proc wsAdd*(ws: WebSocket) =
+  websockets.add ws
+
+proc wsRefreshAll*() =
+  # TODO: Also clean up Closed ones
+  for ws in websockets:
+    if ws.readyState == Open:
+      asyncCheck ws.send "REFRESH"


### PR DESCRIPTION
The general goal of this is that a client can just hit a single
well-known endpoint when coming up, and use that to discover what URLs
to hit for other actions, instead of having to know many.

This offers overkill levels of flexibility on the backend.

Changes here entail:

- Add API endpoint
- Remove some unused imports
- Add a websockets module (unrelated, somewhat random move)
- Move some things around in patchbay module (_slightly_ better encapsulation)

Should probably also:

- Deprecate (or just remove) the old endpoint
- Fix some sorta-whacky variable names in the Arduino sketch