### PR TITLE
Use 1.2.0 in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.1.4
+      with:
+        nim-version: 1.2.0
 
     # (for some reason even w/ a valid binary)
     - run: echo nimble build -y call_status_checker
@@ -47,6 +49,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1.1.4
+      with:
+        nim-version: 1.2.0
 
     - run: nimble build --accept web
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         nim-version: 1.2.0
 
-    - run: nimble build --accept web
+    - run: nimble build --accept
 
   docs:
     # FIXME: Figure out what's actually wrong-- I have a feeling it's just a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-stable
     - uses: jiro4989/setup-nim-action@v1.1.4
+      with:
+        nim-version: 1.2.0
 
     - run: nimble --define:ssl --define:release build --accept "${BINARY_FILENAME}"
 


### PR DESCRIPTION
These should probably match what's in .tool-versions in general...

Determined that this is the source of the following bug I'd seen crop up like this one:
```
[2020-12-15T17:16:22][INFO] Status changed; updating.
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

Should probably set up some kind of integration test to catch this kind of thing.