### PR TITLE
Enable stacktrace and linetrace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         nim-version: 1.2.0
 
-    - run: nimble --define:ssl --define:release build --accept
+    - run: nimble --define:ssl --define:release --stacktrace=on --linetrace=on build --accept
 
     - run: tar -czf "${TARBALL_FILENAME}" "${BINARY_FILENAME}"
 


### PR DESCRIPTION
This change prompted by https://web.archive.org/web/20201229024608/https://blog.johnnovak.net/2020/12/21/nim-apocrypha-vol1/#2--release-builds-with-exception-logging.