### PR TITLE
Avoid HttpBeast w/ Jester

### DIFF
--- a/hk/new
+++ b/hk/new
@@ -16,7 +16,7 @@ heroku addons:create heroku-postgresql:hobby-dev
 
 heroku config:set IS_HEROKU=true
 heroku config:set NIM_REV=3fb5157ab1b666a5a5c34efde0f357a82d433d04 # → v1.4.2
-heroku config:set NIMBLE_FLAGS='--define:release --define:ssl --stacktrace:on --linetrace:on'
+heroku config:set NIMBLE_FLAGS='--define:release --define:ssl --define:useStdLib --stacktrace:on --linetrace:on'
 heroku config:set MQTT_SERVER=mqtt://192.168.86.20:1883
 heroku config:set MQTT_TOPIC=call-status/people
 


### PR DESCRIPTION
Copied directly from https://github.com/dom96/jester/commit/1a11fd0b38ffa3fcebe145aa6b6bb7b1d9f66b74:

> Critical bug: HttpBeast (which is used by default by Jester) currently
> has a bug where data from one request may be sent in response to another
> request under specific circumstances, until this is fixed consider
> compiling your Jester application with -d:useStdLib in order to make use
> of asynchttpserver instead which does not have this bug.