### PR TITLE
Source wifi ssid/pass from env (sort of)

### DIFF
--- a/esp32/.envrc.example
+++ b/esp32/.envrc.example
@@ -1,0 +1,2 @@
+export WIFI_SSID=__WIFI_SSID__
+export WIFI_PASSWORD=__WIFI_PASSWORD__

--- a/esp32/.gitignore
+++ b/esp32/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+main/wifiCredentials.h

--- a/esp32/main/main.ino
+++ b/esp32/main/main.ino
@@ -4,14 +4,12 @@
 #include "HTTPClient.h"
 #include "PubSubClient.h"
 #include "WiFi.h"
+#include "./wifiCredentials.h"
 
 const int LED_BUILTIN = 2;
 const int LED_WIFI_CONNECTED = 16;
 const int LED_P1 = 17;
 const int LED_P2 = 18;
-
-const char* ssid     = "[REDACTED]";
-const char* password = "[REDACTED]";
 
 const char* mqttHost;
 int mqttPort;

--- a/esp32/main/wifiCredentials.template.h
+++ b/esp32/main/wifiCredentials.template.h
@@ -1,0 +1,2 @@
+#define ssid     "$WIFI_SSID"
+#define password "$WIFI_PASSWORD"

--- a/esp32/wifi_credentials.sh
+++ b/esp32/wifi_credentials.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+envsubst < main/wifiCredentials.template.h > main/wifiCredentials.h


### PR DESCRIPTION
Before building, need to run `./wifi_credentials.sh`, but otherwise this keeps that info out of band and lowers risk of accidentally committing them.

There's still some improvement to be had here, but it's a bunch more work so this helps a bunch in the meantime.