### PR TITLE
Config tweaks

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -15,4 +15,5 @@ export DATABASE_FILEPATH=call_status_checker.db
 export REDIS_URL=redis://localhost:6379
 
 export MQTT_SERVER=mqtt://broker.mqttdashboard.com:1883
-export MQTT_TOPIC=call-status/d3768f07ab1d
+export MQTT_TOPIC_PEOPLE=d3768f07ab1d/call-status/people
+export MQTT_TOPIC_HEARTBEAT=d3768f07ab1d/call-status/heartbeat

--- a/src/mqtt.nim
+++ b/src/mqtt.nim
@@ -1,12 +1,8 @@
 import asyncdispatch
-import json
-import oids
 import os
 import strutils
 import tables
 import uri
-
-import ./logs
 
 let server = parseUri getEnv("MQTT_SERVER")
 

--- a/src/mqtt.nim
+++ b/src/mqtt.nim
@@ -3,19 +3,18 @@ import json
 import oids
 import os
 import strutils
+import tables
 import uri
 
 import ./logs
 
-type MqttInfo* = object
-  host*: string
-  port*: int
-  topic*: string
+let server = parseUri getEnv("MQTT_SERVER")
 
-let configured* = block:
-  let uri = parseUri getEnv("MQTT_SERVER")
-  MqttInfo(
-    host: uri.hostname,
-    port: parseInt uri.port,
-    topic: getEnv "MQTT_TOPIC"
-  )
+let host* = server.hostname
+
+let port* = parseInt server.port
+
+let topics* = {
+  "people": getEnv "MQTT_TOPIC_PEOPLE",
+  "heartbeat": getEnv "MQTT_TOPIC_HEARTBEAT"
+}.toTable

--- a/src/web.nim
+++ b/src/web.nim
@@ -52,14 +52,15 @@ router api:
     resp Http204
 
   post "/client/@client_id/up":
-    let path = "/api/people"
     let mqttJson = %*mqtt.configured
     mqttJson["client_id"] = %(@"client_id")
-
-    resp %*{
-      "app_url": request.makeUri path,
-      "mqtt": mqttJson
+    mqttJson["topics"] = %*{
+      "people": mqtt.configured.topic,
+      "heartbeat": "call-status/heartbeat"
     }
+    mqttJson["heartbeat_payload"] = %*{ "client_id": @"client_id" }
+
+    resp %*{ "mqtt": mqttJson }
 
 router web:
   get "/":

--- a/src/web.nim
+++ b/src/web.nim
@@ -52,15 +52,18 @@ router api:
     resp Http204
 
   post "/client/@client_id/up":
-    let mqttJson = %*mqtt.configured
-    mqttJson["client_id"] = %(@"client_id")
-    mqttJson["topics"] = %*{
-      "people": mqtt.configured.topic,
-      "heartbeat": "call-status/heartbeat"
+    resp %*{
+      "mqtt": {
+        "host": mqtt.host,
+        "port": mqtt.port,
+        "client_id": @"client_id",
+        "heartbeat_payload": {"client_id": @"client_id"},
+        "topics": mqtt.topics,
+        # TODO: Remove 'topic' from response once hardware clients all reflashed
+        #       to work with 'topics' instead
+        "topic": mqtt.topics["people"]
+      }
     }
-    mqttJson["heartbeat_payload"] = %*{ "client_id": @"client_id" }
-
-    resp %*{ "mqtt": mqttJson }
 
 router web:
   get "/":


### PR DESCRIPTION
This should allow configuration in just one place, with the hardware clients still being able to Just Work™ without having to be reflashed, at least for the most part.

#### Before:
```sh
curl -s -XPOST 'localhost:5000/api/client/foobarbaz/up' -d'{}' | jq
{
  "app_url": "http://localhost:5000/api/people",
  "mqtt": {
    "host": "127.0.0.1",
    "port": 1883,
    "topic": "call-status/people",
    "client_id": "foobarbaz"
  }
}
```

#### After:
```sh
curl -s -XPOST 'localhost:5000/api/client/foobarbaz/up' -d'{}' | jq
{
  "mqtt": {
    "host": "127.0.0.1",
    "port": 1883,
    "topic": "call-status/people",
    "client_id": "foobarbaz",
    "topics": {
      "people": "call-status/people",
      "heartbeat": "call-status/heartbeat"
    },
    "heartbeat_payload": {
      "client_id": "foobarbaz"
    }
  }
}
```

#### Diff:
```diff
  curl -s -XPOST 'localhost:5000/api/client/foobarbaz/up' -d'{}' | jq
  {
-   "app_url": "http://localhost:5000/api/people",
    "mqtt": {
      "host": "127.0.0.1",
      "port": 1883,
      "topic": "call-status/people",
      "client_id": "foobarbaz",
+     "topics": {
+       "people": "call-status/people",
+       "heartbeat": "call-status/heartbeat"
+     },
+     "heartbeat_payload": {
+       "client_id": "foobarbaz"
+     }
+   }
  }
```