### PR TITLE
Update services

### DIFF
--- a/rpi/call_status_heartbeat_consumer.service
+++ b/rpi/call_status_heartbeat_consumer.service
@@ -4,8 +4,8 @@ Description="Consumes" heartbeat from the ESP32 devices.
 [Service]
 Type=simple
 ExecStart=/bin/bash /usr/bin/call_status_heartbeat_consumer.sh
-Restart=on-failure
-RestartSec=5s
+Restart=always
+RestartSec=2s
 
 [Install]
 WantedBy=default.target

--- a/rpi/call_status_heartbeat_consumer.sh
+++ b/rpi/call_status_heartbeat_consumer.sh
@@ -13,6 +13,14 @@ set -euo pipefail
 readonly topic_heartbeat='call-status/heartbeat'
 readonly topic_heartbeat_latest='call-status/heartbeat/latest'
 
-mosquitto_sub -t "${topic_heartbeat}" \
-  | xargs -L1 -I{} date --iso-8601=s \
-  | xargs -L1 -I{} mosquitto_pub -t "${topic_heartbeat_latest}" -r -m "{}"
+_info() { systemd-cat -t call_status_heartbeat_consumer -p info ; }
+
+_info <<< "Started at $(date --iso-8601=s)"
+
+while true; do
+  mosquitto_sub -t "${topic_heartbeat}" | while read -r line; do
+    msg="$(echo "${line}" | jq -c --arg timestamp "$(date --iso-8601=s)" '. + { $timestamp }')"
+    mosquitto_pub -t "${topic_heartbeat_latest}" -r -m "${msg}"
+  done
+  _info <<< "subscription dropped for some reason; resubscribing…"
+done

--- a/rpi/call_status_heartbeat_consumer.sh
+++ b/rpi/call_status_heartbeat_consumer.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 #
 
 readonly topic_heartbeat='call-status/heartbeat'
-readonly topic_heartbeat_latest='call-status/heartbeat/latest'
+readonly topic_heartbeat_latest="${topic_heartbeat}/latest"
 
 _info() { systemd-cat -t call_status_heartbeat_consumer -p info ; }
 

--- a/rpi/call_status_poll.service
+++ b/rpi/call_status_poll.service
@@ -4,8 +4,8 @@ Description=Polls call status API and publishes to MQTT.
 [Service]
 Type=simple
 ExecStart=/bin/bash /usr/bin/call_status_poll.sh
-Restart=on-failure
-RestartSec=5s
+Restart=always
+RestartSec=2s
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Main change here is in the heartbeat consumer:
```diff
- in: { client_id: <…> } out: <timestamp>
+ in: { client_id: <…> } out: { client_id: <…>, timestamp: <timestamp> }
```

Essentially all it's doing is timestamping incoming heartbeats. If I could be bothered to just have the hardware clients send their own timestamps this middleman wouldn't have to even exist, but here we are.