### PR TITLE
Move the default config file to XDG location

### DIFF
--- a/src/config_file.nim
+++ b/src/config_file.nim
@@ -1,0 +1,6 @@
+import os
+
+type Filepath* = distinct string
+
+let defaultPath*: Filepath =
+  Filepath (os.getConfigDir() / "call_status" / "checker.conf.json")


### PR DESCRIPTION
Default: `~/.config/call_status/checker.conf.json`

The `~/.config/` part should change based on `$XDG_CONFIG_HOME`.