### PR TITLE
Allow database to use XDG_DATA_HOME by default

### DIFF
--- a/src/app_files.nim
+++ b/src/app_files.nim
@@ -1,0 +1,16 @@
+import os
+
+type Filepath* = distinct string
+
+let xdgCacheHome  = os.getEnv("XDG_CACHE_HOME", default = os.expandTilde "~/.cache/")
+let xdgConfigHome = os.getConfigDir()
+let xdgDataHome   = os.getEnv("XDG_DATA_HOME",  default = os.expandTilde "~/.local/share")
+
+let configPath*: Filepath =
+  Filepath (xdgConfigHome / "call_status" / "checker.conf.json")
+
+let databasePath*: Filepath =
+  if existsEnv "DATABASE_FILEPATH":
+    Filepath getEnv("DATABASE_FILEPATH")
+  else:
+    Filepath (xdgDataHome / "call_status" / "checker.db")

--- a/src/checker_config.nim
+++ b/src/checker_config.nim
@@ -3,13 +3,13 @@ import logs
 import options
 import os
 
-import ./config_file
+import ./app_files
 
 const UserName = "user_name"
 
 proc fromString(str: string): Filepath =
   if str == "":
-    config_file.defaultPath
+    app_files.configPath
   else:
     Filepath str
 

--- a/src/config_file.nim
+++ b/src/config_file.nim
@@ -1,6 +1,0 @@
-import os
-
-type Filepath* = distinct string
-
-let defaultPath*: Filepath =
-  Filepath (os.getConfigDir() / "call_status" / "checker.conf.json")

--- a/src/db.nim
+++ b/src/db.nim
@@ -3,6 +3,9 @@ import os
 import db_postgres
 import db_sqlite
 
+import ./app_files
+import ./logs
+
 export db
 
 let postgresUrl = getEnv "DATABASE_URL"
@@ -10,7 +13,9 @@ let postgresUrl = getEnv "DATABASE_URL"
 proc open_pg*(): db_postgres.DbConn =
   db_postgres.open("", "", "", postgresUrl)
 
-let sqliteFilepath = getEnv "DATABASE_FILEPATH"
+let sqliteFilepath = app_files.databasePath.string
 
 proc open_sqlite*(): db_sqlite.DbConn =
+  createDir parentDir(sqliteFilepath)
+  debug "opening: " & sqliteFilepath
   db_sqlite.open(sqliteFilepath, "", "", "")


### PR DESCRIPTION
Still will just use `$DATABASE_FILEPATH` instead if specified, though.