### PR TITLE
Fix release script

### DIFF
--- a/script/gh-actions-release.sh
+++ b/script/gh-actions-release.sh
@@ -7,7 +7,7 @@ _set_env_and_output() {
   local -r value="$2"
 
   echo "${name_cap}=${value}" | tee -a "$GITHUB_ENV"
-  echo "::set-output name=${name_cap,,}::${value}"
+  echo "::set-output name=$(_lower "$name_cap")::${value}"
 }
 
 _checksum() { shasum -a 256 "$1" | cut -d ' ' -f1; }


### PR DESCRIPTION
For some reason this works locally, but not on GH Actions; it's giving
error:
>
> GIT_TAG=0.6.5
> script/gh-actions-release.sh: line 10: ::set-output name=${name_cap,,}::${value}: bad substitution
> Error: Process completed with exit code 1.
>